### PR TITLE
Fixing bug in start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "eslint-check": "eslint --print-config . | eslint-config-prettier-check",
-    "start": "nodemon ./src/request.js --exec babel-node -e js",
+    "start": "nodemon ./src/app.js --exec babel-node -e js",
     "build": "rimraf dist/ && babel ./ --out-dir dist/ --ignore ./node_modules,./.babelrc,./package.json,./npm-debug.log --copy-files",
     "test": "mocha tests/mta-test.js --require babel-core/register",
     "test-with-coverage": "nyc --reporter=text mocha tests/mta-test.js --require babel-core/register",


### PR DESCRIPTION
I noticed that this got changed (probably for debugging). I'm just changing it back to the original so that we don't get any crashes when running `yarn start`.